### PR TITLE
change to use default profile throughout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@
 .idea
 
 # AWS CLI V2 credentials
-aws-admin_credentials.csv
+*credentials*
 
 # backup env files
 .env-cn*
-*env-us*
+.env-us*
 

--- a/createTask/serverless.yml
+++ b/createTask/serverless.yml
@@ -18,9 +18,9 @@ custom:
 
 provider:
   name: aws
-  stage: dev
-  runtime: python3.8
   region: ${env:TARGET_REGION}
+  runtime: python3.8
+  stage: dev
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/createTask/sqsutil.py
+++ b/createTask/sqsutil.py
@@ -10,7 +10,8 @@ def get_sqs_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_sqs_client: region_name={region_name}')
 
-    sqs = boto3.client('sqs',
+    session = boto3.Session(profile_name=None)
+    sqs = session.client('sqs',
         region_name=region_name)
     return sqs
 

--- a/processTask/.dockerignore
+++ b/processTask/.dockerignore
@@ -144,7 +144,7 @@ cython_debug/
 
 # processTask: executables, outputs
 env-cn*.sh
-evn-us*.sh
+env-us*.sh
 task_config.json
 xvsa_scan
 xvsa_scan.exe

--- a/processTask/.gitignore
+++ b/processTask/.gitignore
@@ -143,9 +143,9 @@ cython_debug/
 .idea
 
 # processTask: credentials, executables, outputs
-aws-admin_credentials.csv
+*credentials.csv
 env-cn*.sh
-evn-us*.sh
+env-us*.sh
 xvsa_scan
 xvsa_scan.exe
 *.tar

--- a/processTask/Dockerfile.mock
+++ b/processTask/Dockerfile.mock
@@ -30,7 +30,7 @@ ENV PATH=$PATH:/processTask/bin
 WORKDIR /processTask
 
 # import AWS credentials
-RUN aws configure import --csv "file://aws-admin_credentials.csv"
+RUN aws configure import --csv "file://default_credentials.csv"
 RUN cat ~/.aws/credentials
 
 # set entry point

--- a/processTask/Dockerfile.xvsa
+++ b/processTask/Dockerfile.xvsa
@@ -27,7 +27,7 @@ ENV PATH=$PATH:/processTask/bin
 WORKDIR /processTask
 
 # import AWS credentials
-RUN aws configure import --csv "file://aws-admin_credentials.csv"
+RUN aws configure import --csv "file://default_credentials.csv"
 RUN cat ~/.aws/credentials
 
 CMD ["/bin/sh", "processTask.sh"]

--- a/processTask/s3util.py
+++ b/processTask/s3util.py
@@ -10,7 +10,7 @@ def get_s3_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_s3_client: region_name={region_name}')
 
-    session = boto3.Session(profile_name='aws-admin')
+    session = boto3.Session(profile_name=None)
     s3 = session.client('s3',
         region_name=region_name)
     return s3
@@ -80,4 +80,15 @@ def download_file(bucket_name, object_name, file_name=None):
         logging.error(e)
         return False
     return True
+
+
+def get_file_object(bucket_name, object_name):
+    s3 = get_s3_client()
+    file_object = None
+    try:
+        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return None
+    return file_object
 

--- a/processTask/sqsutil.py
+++ b/processTask/sqsutil.py
@@ -10,7 +10,7 @@ def get_sqs_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_sqs_client: region_name={region_name}')
 
-    session = boto3.Session(profile_name='aws-admin')
+    session = boto3.Session(profile_name=None)
     sqs = session.client('sqs',
         region_name=region_name)
     return sqs

--- a/processTask/taskfile.py
+++ b/processTask/taskfile.py
@@ -11,6 +11,38 @@ def get_task_attribute_value(task, task_attribute_name):
     return task_attribute_value
 
 
+def get_task_file_blob(bucket_name, task, task_file_attribute_name):
+    # get bucket
+    bucket = s3util.get_bucket(bucket_name)
+    if bucket is None:
+        print(f'get_task_file: Bucket {bucket_name} does not exist.')
+        return None
+
+    # get user_id, task_id, task_file_name
+    user_id = get_task_attribute_value(task, 'user_id')
+    if user_id == '':
+        return None
+
+    task_id = get_task_attribute_value(task, 'task_id')
+    if task_id == '':
+        return None
+
+    task_file_name = get_task_attribute_value(task, task_file_attribute_name)
+    if task_file_name == '':
+        return None
+
+    # get $(user_id)/$(task_id)/task_file_name
+    task_file_object_name = user_id + "/" + task_id + "/" + task_file_name
+    task_file_object = s3util.get_file_object(bucket_name, task_file_object_name)
+    if task_file_object is None:
+        print(f'get_task_file: Failed to get scan file object {object_name}')
+        return None
+
+    # success
+    task_file_blob = task_file_object['Body'].read()
+    return task_file_blob
+
+
 def download_task_file(bucket_name, task, task_file_attribute_name):
     # get bucket
     bucket = s3util.get_bucket(bucket_name)

--- a/resources/serverless.yml
+++ b/resources/serverless.yml
@@ -21,9 +21,9 @@ custom:
 
 provider:
   name: aws
+  region: ${env:TARGET_REGION}
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
-  region: ${env:TARGET_REGION}
 
 resources:
   - ${file(./task-exec-preprocess-data-bucket.yml)}

--- a/submitTask/.gitignore
+++ b/submitTask/.gitignore
@@ -142,8 +142,8 @@ cython_debug/
 .idea
 
 # submitTask: credentials
-aws-admin_credentials.csv
+*credentials.csv
 env-cn*.sh
-evn-us*.sh
+env-us*.sh
 preprocess
 

--- a/submitTask/s3util.py
+++ b/submitTask/s3util.py
@@ -10,7 +10,7 @@ def get_s3_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_s3_client: region_name={region_name}')
 
-    session = boto3.Session(profile_name='aws-admin')
+    session = boto3.Session(profile_name=None)
     s3 = session.client('s3',
         region_name=region_name)
     return s3
@@ -80,4 +80,15 @@ def download_file(bucket_name, object_name, file_name=None):
         logging.error(e)
         return False
     return True
+
+
+def get_file_object(bucket_name, object_name):
+    s3 = get_s3_client()
+    file_object = None
+    try:
+        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return None
+    return file_object
 

--- a/submitTask/sqsutil.py
+++ b/submitTask/sqsutil.py
@@ -10,7 +10,7 @@ def get_sqs_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_sqs_client: region_name={region_name}')
 
-    session = boto3.Session(profile_name='aws-admin')
+    session = boto3.Session(profile_name=None)
     sqs = session.client('sqs',
         region_name=region_name)
     return sqs

--- a/submitTask/submitTask.sh
+++ b/submitTask/submitTask.sh
@@ -3,7 +3,7 @@
 . ./env.sh
 
 # import AWS credentials
-aws configure import --csv "file://aws-admin_credentials.csv"
+aws configure import --csv "file://default_credentials.csv"
 cat ~/.aws/credentials
 
 # read task config json, create task id, upload files, submit task

--- a/submitTask/taskfile.py
+++ b/submitTask/taskfile.py
@@ -11,6 +11,38 @@ def get_task_attribute_value(task, task_attribute_name):
     return task_attribute_value
 
 
+def get_task_file_blob(bucket_name, task, task_file_attribute_name):
+    # get bucket
+    bucket = s3util.get_bucket(bucket_name)
+    if bucket is None:
+        print(f'get_task_file: Bucket {bucket_name} does not exist.')
+        return None
+
+    # get user_id, task_id, task_file_name
+    user_id = get_task_attribute_value(task, 'user_id')
+    if user_id == '':
+        return None
+
+    task_id = get_task_attribute_value(task, 'task_id')
+    if task_id == '':
+        return None
+
+    task_file_name = get_task_attribute_value(task, task_file_attribute_name)
+    if task_file_name == '':
+        return None
+
+    # get $(user_id)/$(task_id)/task_file_name
+    task_file_object_name = user_id + "/" + task_id + "/" + task_file_name
+    task_file_object = s3util.get_file_object(bucket_name, task_file_object_name)
+    if task_file_object is None:
+        print(f'get_task_file: Failed to get scan file object {object_name}')
+        return None
+
+    # success
+    task_file_blob = task_file_object['Body'].read()
+    return task_file_blob
+
+
 def download_task_file(bucket_name, task, task_file_attribute_name):
     # get bucket
     bucket = s3util.get_bucket(bucket_name)

--- a/task-list-frontend/serverless.yml
+++ b/task-list-frontend/serverless.yml
@@ -12,9 +12,9 @@ custom:
 
 provider:
   name: aws
+  region: ${env:TARGET_REGION}
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
-  region: ${env:TARGET_REGION}
 
 resources:
   - ${file(./task-list-apps-bucket.yml)}

--- a/task-list-service/serverless.yml
+++ b/task-list-service/serverless.yml
@@ -24,9 +24,9 @@ custom:
 
 provider:
   name: aws
+  region: ${env:TARGET_REGION}
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
-  region: ${env:TARGET_REGION}
   endpointType: regional
   environment:
     TASK_TABLE: '${env:TASK_EXEC_TASK_TABLE}-${self:provider.stage}'

--- a/updateTask/serverless.yml
+++ b/updateTask/serverless.yml
@@ -19,9 +19,9 @@ custom:
 
 provider:
   name: aws
-  stage: dev
-  runtime: python3.8
   region: ${env:TARGET_REGION}
+  runtime: python3.8
+  stage: dev
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/updateTask/sqsutil.py
+++ b/updateTask/sqsutil.py
@@ -10,7 +10,8 @@ def get_sqs_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_sqs_client: region_name={region_name}')
 
-    sqs = boto3.client('sqs',
+    session = boto3.Session(profile_name=None)
+    sqs = session.client('sqs',
         region_name=region_name)
     return sqs
 

--- a/uploadTaskIssues/s3util.py
+++ b/uploadTaskIssues/s3util.py
@@ -10,7 +10,8 @@ def get_s3_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_s3_client: region_name={region_name}')
 
-    s3 = boto3.client('s3',
+    session = boto3.Session(profile_name=None)
+    s3 = session.client('s3',
         region_name=region_name)
     return s3
 

--- a/uploadTaskIssues/serverless.yml
+++ b/uploadTaskIssues/serverless.yml
@@ -19,9 +19,9 @@ custom:
 
 provider:
   name: aws
-  stage: dev
-  runtime: python3.8
   region: ${env:TARGET_REGION}
+  runtime: python3.8
+  stage: dev
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/uploadTaskIssues/sqsutil.py
+++ b/uploadTaskIssues/sqsutil.py
@@ -10,7 +10,8 @@ def get_sqs_client():
         region_name = os.environ['TARGET_REGION']
     print(f'get_sqs_client: region_name={region_name}')
 
-    sqs = boto3.client('sqs',
+    session = boto3.Session(profile_name=None)
+    sqs = session.client('sqs',
         region_name=region_name)
     return sqs
 

--- a/user-service/serverless.yml
+++ b/user-service/serverless.yml
@@ -12,9 +12,9 @@ custom:
 
 provider:
   name: aws
+  region: ${env:TARGET_REGION}
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
-  region: ${env:TARGET_REGION}
 
 resources:
   - ${file(./user-pool.yml)}


### PR DESCRIPTION
change to use default profile throughout.
This allows us to use the same set of the following for all projects:
taskfile.py, s3util.py, taskmessage.py, sqsutil.py.
This means in submitTask and processTask, we have to import default profile (instead of, say, aws-admin profile).

Also cleaned up the parameters in the provider section so that it's consistent:
provider name, region, runtime, stage.

Finally, fixed some typos in .gitignore.